### PR TITLE
Added cleaning for extra whitespaces created during normalization

### DIFF
--- a/scripts/4_EXPRECCE-SENTENCES.ipynb
+++ b/scripts/4_EXPRECCE-SENTENCES.ipynb
@@ -254,7 +254,10 @@
     "    # 7) Collapse multiple spaces again\n",
     "    s = _COLLAPSE_SPACES.sub(\" \", s).strip()\n",
     "\n",
-    "    # 8) Normalize Greek middle dot / ano teleia to period\n",
+    "    # 8) Remove possible spaces before punctuation and apostrophes\n",
+    "    s = re.sub(r\"\\s+([.,;:!?··’'])\", r\"\\1\", s)\n",
+    "\n",
+    "    # 9) Normalize Greek middle dot / ano teleia to period\n",
     "    s = s.replace(\"·\", \".\").replace(\"·\", \".\")\n",
     "    return s"
    ],


### PR DESCRIPTION
Adding normalization caused extra unintended whitespaces before punctuation. This prevented spacy sentence tokenization to give messy results. Simple replace will clear this problem.